### PR TITLE
Remove Mememe UL when No Memes Are Found

### DIFF
--- a/filters/mememe.plugin
+++ b/filters/mememe.plugin
@@ -495,6 +495,10 @@ for i in range(0,len(weighted_links)):
   count = count + 1
   if count >= 10: break
 
+# remove ul when there are no memes
+if memes_ul.lsCountNode() < 1:
+  memes_ul.unlinkNode()
+
 log.info("Writing " + MEMES_ATOM)
 output=open(MEMES_ATOM,'w')
 output.write(feed_doc.serialize('utf-8'))


### PR DESCRIPTION
As it stands, when there are no memes, the plugin produces a &lt;ul/>, which mucks up the formatting of other parts of the sidebar.  This patch simply unlinks the ul if no memes were found.
