### PR TITLE
GeoRSS-Simple support

### DIFF
--- a/planet/reconstitute.py
+++ b/planet/reconstitute.py
@@ -304,6 +304,21 @@ def reconstitute(feed, entry):
     if entry.has_key('geo_lat') and \
         entry.has_key('geo_long'):
         location(xentry, (float)(entry.get('geo_long',None)), (float)(entry.get('geo_lat',None)))
+    if entry.has_key('georss_point'):
+        coordinates = re.split('[,\s]', entry.get('georss_point'))
+        location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
+    elif entry.has_key('georss_line'):
+        coordinates = re.split('[,\s]', entry.get('georss_line'))
+        location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
+    elif entry.has_key('georss_circle'):
+        coordinates = re.split('[,\s]', entry.get('georss_circle'))
+        location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
+    elif entry.has_key('georss_box'):
+        coordinates = re.split('[,\s]', entry.get('georss_box'))
+        location(xentry, ((float)(coordinates[1])+(float)(coordinates[3]))/2, ((float)(coordinates[0])+(float)(coordinates[2]))/2)
+    elif entry.has_key('georss_polygon'):
+        coordinates = re.split('[,\s]', entry.get('georss_polygon'))
+        location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
 
     # author / contributor
     author_detail = entry.get('author_detail',{})

--- a/tests/data/reconstitute/georss_box_latlong.xml
+++ b/tests/data/reconstitute/georss_box_latlong.xml
@@ -1,0 +1,10 @@
+<!--
+Description:  box inside an entry (center point calculated)
+Expect:       geo_lat == '42.991000' and geo_long == '-70.444000'
+-->
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <georss:box>42.943 -71.032 43.039 -69.856</georss:box>
+  </entry>
+</feed>

--- a/tests/data/reconstitute/georss_placeboxpolygon_latlong.xml
+++ b/tests/data/reconstitute/georss_placeboxpolygon_latlong.xml
@@ -1,0 +1,15 @@
+<!--
+Description:  polygon inside bounding box inside place inside an entry
+Expect:       geo_lat == '34.052610' and geo_long == '-118.432212'
+-->
+
+<feed xmlns="http://www.w3.org/2005/Atom"
+  xmlns:twitter="http://api.twitter.com">
+  <entry>
+    <twitter:place xmlns:georss="http://www.georss.org/georss">
+      <twitter:bounding_box>
+        <georss:polygon>34.05260997 -118.43221212 34.05260997 -118.37216196 34.11240804 -118.37216196 34.11240804 -118.43221212</georss:polygon>
+      </twitter:bounding_box>
+    </twitter:place>
+  </entry>
+</feed>

--- a/tests/data/reconstitute/georss_point_latlong.xml
+++ b/tests/data/reconstitute/georss_point_latlong.xml
@@ -1,0 +1,11 @@
+<!--
+Description:  point inside an entry
+Expect:       geo_lat == '34.101646' and geo_long == '-118.326454'
+-->
+
+<feed xmlns="http://www.w3.org/2005/Atom"
+  xmlns:twitter="http://api.twitter.com">
+  <entry>
+    <georss:point>34.10164620,-118.32645359</georss:point>
+  </entry>
+</feed>

--- a/tests/data/reconstitute/georss_polygon_latlong.xml
+++ b/tests/data/reconstitute/georss_polygon_latlong.xml
@@ -1,0 +1,10 @@
+<!--
+Description:  polygon inside an entry
+Expect:       geo_lat == '34.052610' and geo_long == '-118.432212'
+-->
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <georss:polygon>34.052610 -118.432212 34.05260997 -118.37216196 34.11240804 -118.37216196 34.11240804 -118.43221212</georss:polygon>
+  </entry>
+</feed>


### PR DESCRIPTION
Reconstitue now supports folding of GeoRSS into WGS84 latitude and longitude.
