### PR TITLE
Check for planet_name

### DIFF
--- a/planet/shell/_genshi.py
+++ b/planet/shell/_genshi.py
@@ -3,7 +3,9 @@ from xml.sax.saxutils import escape
 
 from genshi.input import HTMLParser, XMLParser
 from genshi.template import Context, MarkupTemplate
+import planet
 
+log = planet.logger
 subscriptions = []
 feed_types = [
     'application/atom+xml',
@@ -28,13 +30,15 @@ def find_config(config, feed):
             if link.has_key('type') and link.type in feed_types:
                 if link.has_key('href') and link.href in subscriptions:
                     return norm(dict(config.parser.items(link.href)))
-
+    
     # match based on name
-    for sub in subscriptions:
-        if config.parser.has_option(sub, 'name') and \
-            norm(config.parser.get(sub, 'name')) == feed.planet_name:
-            return norm(dict(config.parser.items(sub)))
+    if 'planet_name' in feed:
+        for sub in subscriptions:
+            if config.parser.has_option(sub, 'name') and \
+                norm(config.parser.get(sub, 'name')) == feed.planet_name:
+                return norm(dict(config.parser.items(sub)))
 
+    log.warning('Could not match subscription to config: %s', feed.link)
     return {}
 
 class XHTMLParser(object):


### PR DESCRIPTION
Ran into an issue when a feed (http://sandervanrossen.blogspot.com/feeds/posts/default) didn't have a <link rel="self" ... /> matching the original url, and had no name was set in config.ini

```
INFO:planet.runner:Loading cached data
Traceback (most recent call last):
  File "venus/planet.py", line 89, in <module>
    splice.apply(doc.toxml('utf-8'))
  File "/var/www/[...]/venus/planet/splice.py", line 142, in apply
    output_file = shell.run(template_file, doc)
  File "/var/www/[...]/venus/planet/shell/__init__.py", line 66, in run
    module.run(template_resolved, doc, output_file, options)
  File "/var/www/[...]/venus/planet/shell/_genshi.py", line 102, in run
    entry.source.config = find_config(config, entry.source)
  File "/var/www/[...]/venus/planet/shell/_genshi.py", line 35, in find_config
    norm(config.parser.get(sub, 'name')) == feed.planet_name:
  File "/var/www/[...]/venus/planet/vendor/feedparser.py", line 287, in __getattr__
    raise AttributeError, "object has no attribute '%s'" % key
AttributeError: object has no attribute 'planet_name'
```

This commit fixes this issue by first checking if planet_name is available. In addition it writes to the log if it fails to find any configuration.
