### PR TITLE
Fix for duplicate rows in csv subscription list

### DIFF
--- a/planet/csv_config.py
+++ b/planet/csv_config.py
@@ -11,9 +11,12 @@ def csv2config(input, config=None):
         config = ConfigParser()
 
     reader = csv.DictReader(input)
+    d = {}
     for row in reader:
         section = row[reader.fieldnames[0]]
-        config.add_section(section)
+        if not d.get(section):
+            config.add_section(section)
+            d[section] = 1
         for name, value in row.items():
             if value and name != reader.fieldnames[0]:
                 config.set(section, name, value) 

--- a/planet/csv_config.py
+++ b/planet/csv_config.py
@@ -11,12 +11,10 @@ def csv2config(input, config=None):
         config = ConfigParser()
 
     reader = csv.DictReader(input)
-    d = {}
     for row in reader:
         section = row[reader.fieldnames[0]]
-        if not d.get(section):
+        if not config.has_section(section):
             config.add_section(section)
-            d[section] = 1
         for name, value in row.items():
             if value and name != reader.fieldnames[0]:
                 config.set(section, name, value) 

--- a/tests/data/config/basic.csv
+++ b/tests/data/config/basic.csv
@@ -1,3 +1,5 @@
 url,name,filters
 feed1,one
+feed1,one
+feed2,two,bar
 feed2,two,bar


### PR DESCRIPTION
Hi Sam, 

   I just sent the following email to planet devel mailing list. Let me know if this is okay.

--Amit

Hi All,

   I had been chasing this problem for some time and have finally found the issue. If you are using the CSV for subscriptions (e.g. with google spreadsheets) and the subscriptions have duplicates, the entire csv list will not be processed. The error is because ConfigParser would not allow add_section for duplicates.

   I don't know a good way to fix this, but how does the following work ? Let me know if that is okay. I have submitted a pull request to Sam.

Thanks!
Amit
