### PR TITLE
Use the service http://gravatar.com avatar image.

### DIFF
--- a/planet/spider.py
+++ b/planet/spider.py
@@ -20,6 +20,7 @@ re_url_scheme    = re.compile(r'^\w+:/*(\w+:|www\.)?')
 re_slash         = re.compile(r'[?/:|]+')
 re_initial_cruft = re.compile(r'^[,.]*')
 re_final_cruft   = re.compile(r'[,.]*$')
+re_email = '^.+\\@(\\[?)[a-zA-Z0-9\\-\\.]+\\.([a-zA-Z]{2,3}|[0-9]{1,3\})(\\]?)$'
 
 index = True
 
@@ -161,7 +162,10 @@ def writeCache(feed_uri, feed_info, data):
             data.feed.links.append(feedparser.FeedParserDict(
                 {'rel':'self', 'type':feedtype, 'href':feed_uri}))
     for name, value in config.feed_options(feed_uri).items():
-        data.feed['planet_'+name] = value
+        if name == "gravatar" and re.match(re_email, value):
+            data.feed['planet_'+name] = md5(value.strip()).hexdigest()
+        else:
+            data.feed['planet_'+name] = value
 
     # perform user configured scrub operations on the data
     scrub.scrub(feed_uri, data)

--- a/themes/classic_fancy/index.html.tmpl
+++ b/themes/classic_fancy/index.html.tmpl
@@ -51,8 +51,12 @@
 ### variables, but makes them available to us anyway.
 
 <h3><a href="<TMPL_VAR channel_link ESCAPE="HTML">" title="<TMPL_VAR channel_title_plain ESCAPE="HTML">"><TMPL_VAR channel_name></a></h3>
+<TMPL_IF channel_gravatar>
+<img class="face" src="http://gravatar.com/avatar/<TMPL_VAR channel_gravatar ESCAPE="HTML">" alt="">
+<TMPL_ELSE>
 <TMPL_IF channel_face>
 <img class="face" src="images/<TMPL_VAR channel_face ESCAPE="HTML">" width="<TMPL_VAR channel_facewidth ESCAPE="HTML">" height="<TMPL_VAR channel_faceheight ESCAPE="HTML">" alt="">
+</TMPL_IF>
 </TMPL_IF>
 </TMPL_IF>
 


### PR DESCRIPTION
Added option "gravatar" to the configuration file to use the service http://gravatar.com avatar image.

Only works with the theme "classic_fancy. "

example:

  # subscription list
  [http://web-aox.com/feed/]
  name = Alexander Olivares
  gravatar = olivaresa@gmail.com
