### PR TITLE
Restore __main__ module after running a plugin.

### DIFF
--- a/planet/shell/plugin.py
+++ b/planet/shell/plugin.py
@@ -4,6 +4,7 @@ from StringIO import StringIO
 def run(script, doc, output_file=None, options={}):
     """ process an Python script using imp """
     save_sys = (sys.stdin, sys.stdout, sys.stderr, sys.argv)
+    save_main = sys.modules['__main__']
     plugin_stdout = StringIO()
     plugin_stderr = StringIO()
 
@@ -54,6 +55,7 @@ def run(script, doc, output_file=None, options={}):
     finally:
         # restore system state
         sys.stdin, sys.stdout, sys.stderr, sys.argv = save_sys
+        sys.modules['__main__'] = save_main
 
     # log anything sent to stderr
     if plugin_stderr.getvalue():


### PR DESCRIPTION
If the plugin raises an exception (including SystemExit) the `__main__` module is
not properly loaded and it's `__dict__` is lost. E.g. this causes errors when
using any global variable in planet.py. I don't think is is a good idea to keep
the plugin in memory (as `__main__`) anyway.

The original problem I ran into was this:

<pre>
Traceback (most recent call last):
  File "/path/to/venus/planet.py", line 91, in <module>
    if config.pubsubhubbub_hub() and not no_publish:
AttributeError: 'NoneType' object has no attribute 'pubsubhubbub_hub'
</pre>

This happened everytime a plugin (.plugin) raised an exception.
