### PR TITLE
Adjust sanitization code to allow HTML5 'data-' attributes through.

### DIFF
--- a/planet/vendor/feedparser.py
+++ b/planet/vendor/feedparser.py
@@ -2518,6 +2518,8 @@ class _HTMLSanitizer(_BaseHTMLProcessor):
             elif key=='style':
                 clean_value = self.sanitize_style(value)
                 if clean_value: clean_attrs.append((key,clean_value))
+            elif key.startswith('data-'):
+                clean_attrs.append((key, value))
         _BaseHTMLProcessor.unknown_starttag(self, tag, clean_attrs)
         
     def unknown_endtag(self, tag):

--- a/planet/vendor/html5lib/sanitizer.py
+++ b/planet/vendor/html5lib/sanitizer.py
@@ -169,7 +169,7 @@ class HTMLSanitizerMixin(object):
                 if token.has_key("data"):
                     attrs = dict([(name,val) for name,val in
                                   token["data"][::-1] 
-                                  if name in self.allowed_attributes])
+                                  if name in self.allowed_attributes or name.startswith('data-')])
                     for attr in self.attr_val_is_uri:
                         if not attrs.has_key(attr):
                             continue


### PR DESCRIPTION
Basically I have made two minor modifications to files in the `planet/vendor` folder.

Both `planet/vendor/feedparser.py` and `planet/vendor/html5lib/sanitizer.py` (which are used for sanitizing the HTML / XHTML encountered in a feed) strip out [HTML5 data attributes](http://ejohn.org/blog/html-5-data-attributes/). These attributes have no meaning to the browser (they are ignored) but third party scripts that are added to the planet page may make use of these attributes and having them stripped out breaks the scripts (or causes them to fail).

Therefore, I have modified the two above files to allow these attributes to pass through the filtering / sanitization unaltered.

Please let me know if you have any questions / concerns.
