### PR TITLE
Use a user-agent other than the httplib2 default.

### DIFF
--- a/planet/spider.py
+++ b/planet/spider.py
@@ -322,6 +322,8 @@ def httpThread(thread_index, input_queue, output_queue, log):
                 headers['If-Modified-Since'] = \
                     feed_info.feed['planet_http_last_modified']
 
+            headers['user-agent'] = 'venus'
+
             # issue request
             (resp, content) = h.request(idna, 'GET', headers=headers)
 


### PR DESCRIPTION
There is something about the default httplib2 user-agent that causes some web
servers to throw up.

Try this, for example::

```
>>> import httplib2
>>> h = httplib2.Http()
>>> response, content = h.request(
...   "http://ankursinha.in/blog/feed/")
>>> response.status
406
>>> response, content = h.request(
...   "http://ankursinha.in/blog/feed/",
...   headers={'user-agent': 'trololololololol 9000'})
>>> response.status
200
```
