### PR TITLE
Handle varieties of empty <georss:point> element

### DIFF
--- a/planet/reconstitute.py
+++ b/planet/reconstitute.py
@@ -42,7 +42,7 @@ def createTextElement(parent, name, value):
     parent.appendChild(xelement)
     return xelement
 
-def invalidate(c): 
+def invalidate(c):
     """ replace invalid characters """
     return u'<abbr title="U+%s">\ufffd</abbr>' % \
         ('000' + hex(ord(c.group(0)))[2:])[-4:]
@@ -81,7 +81,7 @@ def id(xentry, entry):
             md5(entry.summary).hexdigest())
     elif entry.has_key("content") and entry.content:
 
-        entry_id = (entry.content[0].base + "/" + 
+        entry_id = (entry.content[0].base + "/" +
             md5(entry.content[0].value).hexdigest())
     else:
         return
@@ -94,7 +94,7 @@ def links(xentry, entry):
     if not entry.has_key('links'):
        entry['links'] = []
        if entry.has_key('link'):
-         entry['links'].append({'rel':'alternate', 'href':entry.link}) 
+         entry['links'].append({'rel':'alternate', 'href':entry.link})
     xdoc = xentry.ownerDocument
     for link in entry['links']:
         if not 'href' in link.keys(): continue
@@ -141,7 +141,7 @@ def author(xentry, name, detail):
 
     createTextElement(xauthor, 'email', detail.get('email', None))
     createTextElement(xauthor, 'uri', detail.get('href', None))
-        
+
     xentry.appendChild(xauthor)
 
 def content(xentry, name, detail, bozo):
@@ -234,7 +234,7 @@ def source(xsource, source, bozo, format):
 
     if not source.has_key('links') and source.has_key('href'): #rss
         source['links'] = [{ 'href': source.get('href') }]
-        if source.has_key('title'): 
+        if source.has_key('title'):
             source['links'][0]['title'] = source.get('title')
     links(xsource, source)
 
@@ -312,7 +312,8 @@ def reconstitute(feed, entry):
         location(xentry, (float)(entry.get('geo_long',None)), (float)(entry.get('geo_lat',None)))
     if entry.has_key('georss_point'):
         coordinates = re.split('[,\s]', entry.get('georss_point'))
-        location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
+        if len(coordinates) >= 2:
+            location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
     elif entry.has_key('georss_line'):
         coordinates = re.split('[,\s]', entry.get('georss_line'))
         location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))


### PR DESCRIPTION
Empty point defined as `<georss:point> </georss:point>` with single space only leads to index out of range on the coordinates access.

From the log:

```
ERROR:planet.runner:Error processing http://example.com/feed
ERROR:planet.runner:IndexError: list index out of range
ERROR:planet.runner:  File "/opt/venus/planet/spider.py", line 480, in spiderPlanet
    writeCache(uri, feed_info, data)
ERROR:planet.runner:  File "/opt/venus/planet/spider.py", line 228, in writeCache
    xdoc = reconstitute.reconstitute(data, entry)
ERROR:planet.runner:  File "/opt/venus/planet/reconstitute.py", line 315, in reconstitute
    location(xentry, (float)(coordinates[1]), (float)(coordinates[0]))
```

It looks rope-vim plugin I use with Vim automatically applied a bit of refactoring on unifying indentation. I hope it's not a showstopper :)
If it is a problem, let me know and I'll prepare clean patch.
