### PR TITLE
load system locale

### DIFF
--- a/planet.py
+++ b/planet.py
@@ -14,9 +14,10 @@ __authors__ = [ "Scott James Remnant <scott@netsplit.com>",
 __license__ = "Python"
 
 
-import os, sys
+import os, sys, locale
 
 if __name__ == "__main__":
+    locale.setlocale(locale.LC_ALL, '')
     config_file = []
     offline = 0
     verbose = 0

--- a/planet/shell/tmpl.py
+++ b/planet/shell/tmpl.py
@@ -1,5 +1,5 @@
 from xml.sax.saxutils import escape
-import sgmllib, time, os, sys, new, urlparse, re
+import sgmllib, time, os, sys, new, urlparse, re, locale
 from planet import config, feedparser
 import htmltmpl
 
@@ -62,7 +62,10 @@ def NewDate(value):
     return time.strftime(config.new_date_format(), value)
 
 def Rfc822(value):
-    return time.strftime("%a, %d %b %Y %H:%M:%S +0000", value)
+    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+    nv = time.strftime("%a, %d %b %Y %H:%M:%S +0000", value)
+    locale.setlocale(locale.LC_ALL, "")
+    return nv
 
 def Rfc3399(value):
     return time.strftime("%Y-%m-%dT%H:%M:%S+00:00", value)

--- a/planet/spider.py
+++ b/planet/spider.py
@@ -160,6 +160,8 @@ def writeCache(feed_uri, feed_info, data):
         else:
             data.feed.links.append(feedparser.FeedParserDict(
                 {'rel':'self', 'type':feedtype, 'href':feed_uri}))
+    if not data.has_key('version'):
+        data.version = 'rss10'
     for name, value in config.feed_options(feed_uri).items():
         data.feed['planet_'+name] = value
 


### PR DESCRIPTION
The "locale" variable was removed from configuration file format. However the system locale is not used.

Steps to reproduce:

LANG=cs_CZ.utf-8 ./planet.py ./config.ini
LANG=en_US.utf-8 ./planet.py ./config.ini

This patch should add default locale to time.strftime(format[, t]) call.
