### PR TITLE
Code cleanup for modernization.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,27 +1,20 @@
 #!/usr/bin/env python
-import glob, unittest, os, sys
-
-# python 2.2 accomodations
-try:
-    from trace import fullmodname
-except:
-    def fullmodname(path):
-        return os.path.splitext(path)[0].replace(os.sep, '.')
-
-# more python 2.2 accomodations
-if not hasattr(unittest.TestCase, 'assertTrue'):
-    unittest.TestCase.assertTrue = unittest.TestCase.assert_
-if not hasattr(unittest.TestCase, 'assertFalse'):
-    unittest.TestCase.assertFalse = unittest.TestCase.failIf
+# coding=utf-8
+import glob
+import os
+import sys
+import unittest
+from trace import fullmodname
 
 # try to start in a consistent, predictable location
-if sys.path[0]: os.chdir(sys.path[0])
+if sys.path[0]:
+    os.chdir(sys.path[0])
 sys.path[0] = os.getcwd()
 
 # determine verbosity
 verbosity = 1
-for arg,value in (('-q',0),('--quiet',0),('-v',2),('--verbose',2)):
-    if arg in sys.argv: 
+for arg, value in (('-q', 0), ('--quiet', 0), ('-v', 2), ('--verbose', 2)):
+    if arg in sys.argv:
         verbosity = value
         sys.argv.remove(arg)
 
@@ -32,16 +25,21 @@ for pattern in sys.argv[1:] or ['test_*.py']:
 
 # enable logging
 import planet
-if verbosity == 0: planet.getLogger("FATAL",None)
-if verbosity == 1: planet.getLogger("WARNING",None)
-if verbosity == 2: planet.getLogger("DEBUG",None)
+
+if verbosity == 0:
+    planet.getLogger("FATAL", None)
+if verbosity == 1:
+    planet.getLogger("WARNING", None)
+if verbosity == 2:
+    planet.getLogger("DEBUG", None)
 
 # load all of the tests into a suite
 try:
     suite = unittest.TestLoader().loadTestsFromNames(modules)
-except Exception, exception:
+except Exception as exception:
     # attempt to produce a more specific message
-    for module in modules: __import__(module)
+    for each_module in modules:
+        __import__(each_module)
     raise
 
 # run test suite

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/tests/capture.py
+++ b/tests/capture.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 """
 While unit tests are intended to be independently executable, it often
@@ -9,7 +10,9 @@ This script captures such output.  It should be run whenever there is
 a major change in the contract between stages
 """
 
-import shutil, os, sys
+import os
+import shutil
+import sys
 
 # move up a directory
 sys.path.insert(0, os.path.split(sys.path[0])[0])
@@ -18,7 +21,8 @@ os.chdir(sys.path[0])
 # copy spider output to splice input
 import planet
 from planet import spider, config
-planet.getLogger('CRITICAL',None)
+
+planet.getLogger('CRITICAL', None)
 
 config.load('tests/data/spider/config.ini')
 spider.spiderPlanet()
@@ -26,26 +30,24 @@ if os.path.exists('tests/data/splice/cache'):
     shutil.rmtree('tests/data/splice/cache')
 shutil.move('tests/work/spider/cache', 'tests/data/splice/cache')
 
-source=open('tests/data/spider/config.ini')
-dest1=open('tests/data/splice/config.ini', 'w')
-dest1.write(source.read().replace('/work/spider/', '/data/splice/'))
-dest1.close()
 
-source.seek(0)
-dest2=open('tests/work/apply_config.ini', 'w')
-dest2.write(source.read().replace('[Planet]', '''[Planet]
-output_theme = asf
-output_dir = tests/work/apply'''))
-dest2.close()
-source.close()
+with open('tests/data/spider/config.ini') as source, \
+        open('tests/data/splice/config.ini', 'w') as dest1:
+    dest1.write(source.read().replace('/work/spider/', '/data/splice/'))
+
+with open('tests/data/spider/config.ini') as source, \
+        open('tests/work/apply_config.ini', 'w') as dest2:
+    dest2.write(source.read().replace('[Planet]', '''[Planet]
+    output_theme = asf
+    output_dir = tests/work/apply'''))
 
 # copy splice output to apply input
 from planet import splice
-file=open('tests/data/apply/feed.xml', 'w')
-config.load('tests/data/splice/config.ini')
-data=splice.splice().toxml('utf-8')
-file.write(data)
-file.close()
+
+with open('tests/data/apply/feed.xml', 'w') as fp:
+    config.load('tests/data/splice/config.ini')
+    data = splice.splice().toxml('utf-8')
+    fp.write(data)
 
 # copy apply output to config/reading-list input
 config.load('tests/work/apply_config.ini')

--- a/tests/data/apply/rebase.py
+++ b/tests/data/apply/rebase.py
@@ -1,24 +1,30 @@
+# coding=utf-8
 # make href attributes absolute, using base argument passed in
 
+from __future__ import print_function
+
 import sys
+
 try:
-  base = sys.argv[sys.argv.index('--base')+1]
-except:
-  sys.stderr.write('Missing required argument: base\n')
-  sys.exit()
+    base = sys.argv[sys.argv.index('--base') + 1]
+except ValueError:
+    sys.stderr.write('Missing required argument: base\n')
+    sys.exit()
 
 from xml.dom import minidom, Node
 from urlparse import urljoin
 
+
 def rebase(node, newbase):
-  if node.hasAttribute('href'):
-    href=node.getAttribute('href')
-    if href != urljoin(base,href):
-      node.setAttribute('href', urljoin(base,href))
-  for child in node.childNodes:
-    if child.nodeType == Node.ELEMENT_NODE:
-      rebase(child, newbase)
+    if node.hasAttribute('href'):
+        href = node.getAttribute('href')
+        if href != urljoin(base, href):
+            node.setAttribute('href', urljoin(base, href))
+    for child in node.childNodes:
+        if child.nodeType == Node.ELEMENT_NODE:
+            rebase(child, newbase)
+
 
 doc = minidom.parse(sys.stdin)
 rebase(doc.documentElement, base)
-print doc.toxml('utf-8')
+print(doc.toxml('utf-8'))

--- a/tests/reconstitute.py
+++ b/tests/reconstitute.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
-import os, sys, ConfigParser, shutil, glob
+# coding=utf-8
+from __future__ import print_function
+
+import ConfigParser
+import glob
+import os
+import shutil
+import sys
+
 venus_base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0,venus_base)
+sys.path.insert(0, venus_base)
 
 if __name__ == "__main__":
     import planet
-    planet.getLogger('WARN',None)
+
+    planet.getLogger('WARN', None)
 
     hide_planet_ns = True
 
@@ -21,40 +30,44 @@ if __name__ == "__main__":
     parser = ConfigParser.ConfigParser()
     parser.add_section('Planet')
     parser.add_section(sys.argv[1])
-    work = reduce(os.path.join, ['tests','work','reconsititute'], venus_base)
+    work = reduce(os.path.join, ['tests', 'work', 'reconsititute'], venus_base)
     output = os.path.join(work, 'output')
-    filters = os.path.join(venus_base,'filters')
-    parser.set('Planet','cache_directory',work)
-    parser.set('Planet','output_dir',output)
-    parser.set('Planet','filter_directories',filters)
+    filters = os.path.join(venus_base, 'filters')
+    parser.set('Planet', 'cache_directory', work)
+    parser.set('Planet', 'output_dir', output)
+    parser.set('Planet', 'filter_directories', filters)
     if hide_planet_ns:
-        parser.set('Planet','template_files','themes/common/atom.xml.xslt')
+        parser.set('Planet', 'template_files', 'themes/common/atom.xml.xslt')
     else:
-        parser.set('Planet','template_files','tests/data/reconstitute.xslt')
+        parser.set('Planet', 'template_files', 'tests/data/reconstitute.xslt')
 
-    for name, value in zip(sys.argv[2::2],sys.argv[3::2]):
+    for name, value in zip(sys.argv[2::2], sys.argv[3::2]):
         parser.set(sys.argv[1], name.lstrip('-'), value)
 
     from planet import config
+
     config.parser = parser
 
     from planet import spider
+
     spider.spiderPlanet(only_if_new=False)
 
     import feedparser
+
     for source in glob.glob(os.path.join(work, 'sources/*')):
         feed = feedparser.parse(source).feed
-        if feed.has_key('title'):
-            config.parser.set('Planet','name',feed.title_detail.value)
-        if feed.has_key('link'):
-            config.parser.set('Planet','link',feed.link)
-        if feed.has_key('author_detail'):
-            if feed.author_detail.has_key('name'):
-                config.parser.set('Planet','owner_name',feed.author_detail.name)
-            if feed.author_detail.has_key('email'):
-                config.parser.set('Planet','owner_email',feed.author_detail.email)
+        if 'title' in feed.keys():
+            config.parser.set('Planet', 'name', feed.title_detail.value)
+        if 'link' in feed.keys():
+            config.parser.set('Planet', 'link', feed.link)
+        if 'author_detail' in feed.keys():
+            if 'name' in feed.author_detail.keys():
+                config.parser.set('Planet', 'owner_name', feed.author_detail.name)
+            if 'email' in feed.author_detail.keys():
+                config.parser.set('Planet', 'owner_email', feed.author_detail.email)
 
     from planet import splice
+
     doc = splice.splice()
 
     sources = doc.getElementsByTagName('planet:source')
@@ -63,26 +76,29 @@ if __name__ == "__main__":
         feed = source.parentNode
         child = feed.firstChild
         while child:
-            next = child.nextSibling
-            if child.nodeName not in ['planet:source','entry']:
+            next_ = child.nextSibling
+            if child.nodeName not in ['planet:source', 'entry']:
                 feed.removeChild(child)
-            child = next
+            child = next_
         while source.hasChildNodes():
             child = source.firstChild
             source.removeChild(child)
             feed.insertBefore(child, source)
-        atomNS='http://www.w3.org/2005/Atom'
+        atomNS = 'http://www.w3.org/2005/Atom'
         for source in doc.getElementsByTagNameNS(atomNS, 'source'):
             source.parentNode.removeChild(source)
 
     splice.apply(doc.toxml('utf-8'))
 
     if hide_planet_ns:
-        atom = open(os.path.join(output,'atom.xml')).read()
+        atom_path = os.path.join(output, 'atom.xml')
     else:
-        atom = open(os.path.join(output,'reconstitute')).read()
+        atom_path = os.path.join(output, 'reconstitute')
+
+    with open(atom_path) as fp:
+        atom = fp.read()
 
     shutil.rmtree(work)
     os.removedirs(os.path.dirname(work))
 
-    print atom
+    print(atom)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,25 +1,29 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, shutil
-from planet import config, splice, logger
+import os
+import shutil
+import unittest
 from xml.dom import minidom
+
+import test_filter_genshi
+from planet import config, logger, splice
 
 workdir = 'tests/work/apply'
 configfile = 'tests/data/apply/config-%s.ini'
 testfeed = 'tests/data/apply/feed.xml'
 
+
 class ApplyTest(unittest.TestCase):
     def setUp(self):
-        testfile = open(testfeed)
-        self.feeddata = testfile.read()
-        testfile.close()
-
+        with open(testfeed) as testfile:
+            self.feeddata = testfile.read()
         try:
-             os.makedirs(workdir)
+            os.makedirs(workdir)
         except:
-             self.tearDown()
-             os.makedirs(workdir)
-    
+            self.tearDown()
+            os.makedirs(workdir)
+
     def tearDown(self):
         shutil.rmtree(os.path.split(workdir)[0])
 
@@ -27,21 +31,21 @@ class ApplyTest(unittest.TestCase):
         splice.apply(self.feeddata)
 
         # verify that selected files are there
-        for file in ['index.html', 'default.css', 'images/foaf.png']:
-            path = os.path.join(workdir, file)
+        for each_file in ['index.html', 'default.css', 'images/foaf.png']:
+            path = os.path.join(workdir, each_file)
             self.assertTrue(os.path.exists(path))
-            self.assertTrue(os.stat(path).st_size > 0, file + ' has size 0')
+            self.assertTrue(os.stat(path).st_size > 0, each_file + ' has size 0')
 
         # verify that index.html is well formed, has content, and xml:lang
-        html = open(os.path.join(workdir, 'index.html'))
-        doc = minidom.parse(html)
-        list = []
-        content = lang = 0
-        for div in doc.getElementsByTagName('div'):
-            if div.getAttribute('class') != 'content': continue
-            content += 1
-            if div.getAttribute('xml:lang') == 'en-us': lang += 1
-        html.close()
+        with open(os.path.join(workdir, 'index.html')) as html:
+            doc = minidom.parse(html)
+            content = lang = 0
+            for div in doc.getElementsByTagName('div'):
+                if div.getAttribute('class') != 'content':
+                    continue
+                content += 1
+                if div.getAttribute('xml:lang') == 'en-us':
+                    lang += 1
         self.assertEqual(12, content)
         self.assertEqual(3, lang)
 
@@ -61,75 +65,81 @@ class ApplyTest(unittest.TestCase):
         config.load(configfile % 'html')
         self.apply_asf()
 
-        output = open(os.path.join(workdir, 'index.html')).read()
-        self.assertTrue(output.find('/>')>=0)
+        with open(os.path.join(workdir, 'index.html')) as html:
+            self.assertTrue(html.read().find('/>') >= 0)
 
-        output = open(os.path.join(workdir, 'index.html4')).read()
-        self.assertTrue(output.find('/>')<0)
+        with open(os.path.join(workdir, 'index.html4')) as html:
+            self.assertTrue(html.read().find('/>') < 0)
 
     def test_apply_filter_mememe(self):
         config.load(configfile % 'mememe')
         self.apply_fancy()
-    
-        output = open(os.path.join(workdir, 'index.html')).read()
-        self.assertTrue(output.find('<div class="sidebar"><h2>Memes <a href="memes.atom">')>=0)
+
+        with open(os.path.join(workdir, 'index.html')) as html:
+            self.assertTrue(html.read().find('<div class="sidebar"><h2>Memes <a href="memes.atom">') >= 0)
 
     def apply_fancy(self):
         # drop slow templates unrelated to test at hand
-        templates = config.parser.get('Planet','template_files').split()
+        templates = config.parser.get('Planet', 'template_files').split()
         templates.remove('rss10.xml.tmpl')
         templates.remove('rss20.xml.tmpl')
-        config.parser.set('Planet','template_files',' '.join(templates))
-        
+        config.parser.set('Planet', 'template_files', ' '.join(templates))
+
         splice.apply(self.feeddata)
 
         # verify that selected files are there
-        for file in ['index.html', 'planet.css', 'images/jdub.png']:
-            path = os.path.join(workdir, file)
+        for each_file in ['index.html', 'planet.css', 'images/jdub.png']:
+            path = os.path.join(workdir, each_file)
             self.assertTrue(os.path.exists(path), path)
             self.assertTrue(os.stat(path).st_size > 0)
 
         # verify that index.html is well formed, has content, and xml:lang
-        html = open(os.path.join(workdir, 'index.html')).read()
-        self.assertTrue(html.find('<h1>test planet</h1>')>=0)
-        self.assertTrue(html.find(
-          '<h4><a href="http://example.com/2">Venus</a></h4>')>=0)
+        with open(os.path.join(workdir, 'index.html')) as fp:
+            html = fp.read()
+            self.assertTrue(html.find('<h1>test planet</h1>') >= 0)
+            self.assertTrue(html.find(
+                '<h4><a href="http://example.com/2">Venus</a></h4>') >= 0)
 
     def test_apply_filter(self):
         config.load(configfile % 'filter')
         splice.apply(self.feeddata)
 
         # verify that index.html is well formed, has content, and xml:lang
-        html = open(os.path.join(workdir, 'index.html')).read()
-        self.assertTrue(html.find(' href="http://example.com/default.css"')>=0)
+        with open(os.path.join(workdir, 'index.html')) as fp:
+            html = fp.read()
+            self.assertTrue(html.find(' href="http://example.com/default.css"') >= 0)
 
-import test_filter_genshi
+
 for method in dir(test_filter_genshi.GenshiFilterTests):
-    if method.startswith('test_'): break
+    if method.startswith('test_'):
+        break
 else:
-    delattr(ApplyTest,'test_apply_genshi_fancy')
+    delattr(ApplyTest, 'test_apply_genshi_fancy')
 
 try:
     import libxml2
 except ImportError:
 
-    delattr(ApplyTest,'test_apply_filter_mememe')
+    delattr(ApplyTest, 'test_apply_filter_mememe')
 
     try:
         import win32pipe
-        (stdin,stdout) = win32pipe.popen4('xsltproc -V', 't')
+
+        (stdin, stdout) = win32pipe.popen4('xsltproc -V', 't')
         stdin.close()
         stdout.read()
         try:
             exitcode = stdout.close()
         except IOError:
             exitcode = -1
-    except:
+    except ImportError:
         import commands
-        (exitstatus,output) = commands.getstatusoutput('xsltproc -V')
-        exitcode = ((exitstatus>>8) & 0xFF)
+
+        (exitstatus, output) = commands.getstatusoutput('xsltproc -V')
+        exitcode = ((exitstatus >> 8) & 0xFF)
 
     if exitcode:
         logger.warn("xsltproc is not available => can't test XSLT templates")
         for method in dir(ApplyTest):
-            if method.startswith('test_'):  delattr(ApplyTest,method)
+            if method.startswith('test_'):
+                delattr(ApplyTest, method)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import unittest
+
 from planet import config
+
 
 class ConfigTest(unittest.TestCase):
     def setUp(self):
@@ -10,8 +13,8 @@ class ConfigTest(unittest.TestCase):
     # administrivia
 
     def test_template(self):
-        self.assertEqual(['index.html.tmpl', 'atom.xml.tmpl'], 
-            config.template_files())
+        self.assertEqual(['index.html.tmpl', 'atom.xml.tmpl'],
+                         config.template_files())
 
     def test_feeds(self):
         feeds = config.subscriptions()
@@ -55,17 +58,14 @@ class ConfigTest(unittest.TestCase):
 
     def test_template_options(self):
         option = config.template_options('index.html.tmpl')
-        self.assertEqual('7',  option['days_per_page'])
+        self.assertEqual('7', option['days_per_page'])
         self.assertEqual('50', option['items_per_page'])
 
     def test_filters(self):
-        self.assertEqual(['foo','bar'], config.filters('feed2'))
+        self.assertEqual(['foo', 'bar'], config.filters('feed2'))
         self.assertEqual(['foo'], config.filters('feed1'))
 
     # ints
 
     def test_timeout(self):
-        self.assertEqual(30,
-            config.feed_timeout())
-
-
+        self.assertEqual(30, config.feed_timeout())

--- a/tests/test_config_csv.py
+++ b/tests/test_config_csv.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import os, shutil, unittest
+import os
+import shutil
+import unittest
+
 from planet import config
 
 workdir = os.path.join('tests', 'work', 'config', 'cache')
+
 
 class ConfigCsvTest(unittest.TestCase):
     def setUp(self):
@@ -21,5 +26,5 @@ class ConfigCsvTest(unittest.TestCase):
         self.assertEqual(['feed1', 'feed2'], feeds)
 
     def test_filters(self):
-        self.assertEqual(['foo','bar'], config.filters('feed2'))
+        self.assertEqual(['foo', 'bar'], config.filters('feed2'))
         self.assertEqual(['foo'], config.filters('feed1'))

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,31 +1,36 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, re
-from xml.dom import minidom
+import os
+import re
+import unittest
 from glob import glob
 from htmlentitydefs import name2codepoint as n2cp
+from xml.dom import minidom
+
 
 class DocsTest(unittest.TestCase):
-
     def test_well_formed(self):
         def substitute_entity(match):
             ent = match.group(1)
             try:
-                  return "&#%d;" % n2cp[ent]
+                return "&#%d;" % n2cp[ent]
             except:
-                  return "&%s;" % ent
+                return "&%s;" % ent
 
         for doc in glob('docs/*'):
-            if os.path.isdir(doc): continue
-            if doc.endswith('.css') or doc.endswith('.js'): continue
-
-            source = open(doc).read()
-            source = re.sub('&(\w+);', substitute_entity, source)
+            if os.path.isdir(doc):
+                continue
+            if doc.endswith('.css') or doc.endswith('.js'):
+                continue
+            with open(doc) as fp:
+                source = fp.read()
+                source = re.sub('&(\w+);', substitute_entity, source)
 
             try:
                 minidom.parseString(source)
             except:
-                self.fail('Not well formed: ' + doc);
-                break
+                self.fail('Not well formed: ' + doc)
+
         else:
-            self.assertTrue(True);
+            self.assertTrue(True)

--- a/tests/test_expunge.py
+++ b/tests/test_expunge.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
-import unittest, os, glob, shutil, time
-from planet.spider import filename
-from planet import feedparser, config
-from planet.expunge import expungeCache
+# coding=utf-8
+import glob
+import os
+import shutil
+import time
+import unittest
 from xml.dom import minidom
+
 import planet
+from planet import config, feedparser
+from planet.expunge import expungeCache
+from planet.spider import filename
 
 workdir = 'tests/work/expunge/cache'
 sourcesdir = 'tests/work/expunge/cache/sources'
@@ -12,11 +18,12 @@ testentries = 'tests/data/expunge/test*.entry'
 testfeeds = 'tests/data/expunge/test*.atom'
 configfile = 'tests/data/expunge/config.ini'
 
+
 class ExpungeTest(unittest.TestCase):
     def setUp(self):
         # silence errors
         self.original_logger = planet.logger
-        planet.getLogger('CRITICAL',None)
+        planet.getLogger('CRITICAL', None)
 
         try:
             os.makedirs(workdir)
@@ -25,7 +32,7 @@ class ExpungeTest(unittest.TestCase):
             self.tearDown()
             os.makedirs(workdir)
             os.makedirs(sourcesdir)
-             
+
     def tearDown(self):
         shutil.rmtree(workdir)
         os.removedirs(os.path.split(workdir)[0])
@@ -36,49 +43,51 @@ class ExpungeTest(unittest.TestCase):
 
         # create test entries in cache with correct timestamp
         for entry in glob.glob(testentries):
-            e=minidom.parse(entry)
+            e = minidom.parse(entry)
             e.normalize()
             eid = e.getElementsByTagName('id')
             efile = filename(workdir, eid[0].childNodes[0].nodeValue)
             eupdated = e.getElementsByTagName('updated')[0].childNodes[0].nodeValue
             emtime = time.mktime(feedparser._parse_date_w3dtf(eupdated))
-            if not eid or not eupdated: continue
+            if not eid or not eupdated:
+                continue
             shutil.copyfile(entry, efile)
             os.utime(efile, (emtime, emtime))
-  
+
         # create test feeds in cache
         sources = config.cache_sources_directory()
         for feed in glob.glob(testfeeds):
-                f=minidom.parse(feed)
-                f.normalize()
-                fid = f.getElementsByTagName('id')
-                if not fid: continue
-                ffile = filename(sources, fid[0].childNodes[0].nodeValue)
-                shutil.copyfile(feed, ffile)
+            f = minidom.parse(feed)
+            f.normalize()
+            fid = f.getElementsByTagName('id')
+            if not fid:
+                continue
+            ffile = filename(sources, fid[0].childNodes[0].nodeValue)
+            shutil.copyfile(feed, ffile)
 
         # verify that exactly nine entries + one source dir were produced
-        files = glob.glob(workdir+"/*")
+        files = glob.glob(workdir + "/*")
         self.assertEqual(10, len(files))
 
         # verify that exactly four feeds were produced in source dir
-        files = glob.glob(sources+"/*")
+        files = glob.glob(sources + "/*")
         self.assertEqual(4, len(files))
 
         # expunge...
         expungeCache()
 
         # verify that five entries and one source dir are left
-        files = glob.glob(workdir+"/*")
+        files = glob.glob(workdir + "/*")
         self.assertEqual(6, len(files))
 
         # verify that the right five entries are left
         self.assertTrue(os.path.join(workdir,
-            'bzr.mfd-consult.dk,2007,venus-expunge-test1,1') in files)
+                                     'bzr.mfd-consult.dk,2007,venus-expunge-test1,1') in files)
         self.assertTrue(os.path.join(workdir,
-            'bzr.mfd-consult.dk,2007,venus-expunge-test2,1') in files)
+                                     'bzr.mfd-consult.dk,2007,venus-expunge-test2,1') in files)
         self.assertTrue(os.path.join(workdir,
-            'bzr.mfd-consult.dk,2007,venus-expunge-test3,3') in files)
+                                     'bzr.mfd-consult.dk,2007,venus-expunge-test3,3') in files)
         self.assertTrue(os.path.join(workdir,
-            'bzr.mfd-consult.dk,2007,venus-expunge-test4,2') in files)
+                                     'bzr.mfd-consult.dk,2007,venus-expunge-test4,2') in files)
         self.assertTrue(os.path.join(workdir,
-            'bzr.mfd-consult.dk,2007,venus-expunge-test4,3') in files)
+                                     'bzr.mfd-consult.dk,2007,venus-expunge-test4,3') in files)

--- a/tests/test_filter_django.py
+++ b/tests/test_filter_django.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
+# coding=utf-8
 
+import datetime
 import os.path
-import unittest, xml.dom.minidom, datetime
+import unittest
 
 from planet import config, logger
 from planet.shell import dj
 
-class DjangoFilterTests(unittest.TestCase):
 
+class DjangoFilterTests(unittest.TestCase):
     def test_django_filter(self):
         config.load('tests/data/filter/django/test.ini')
         results = dj.tmpl.template_info("<feed/>")
@@ -20,34 +22,35 @@ class DjangoFilterTests(unittest.TestCase):
 
     def test_django_entry_title(self):
         config.load('tests/data/filter/django/test.ini')
-        feed = open('tests/data/filter/django/test.xml')
-        input = feed.read(); feed.close()
+        with open('tests/data/filter/django/test.xml') as feed:
+            input_ = feed.read()
         results = dj.run(
-            os.path.realpath('tests/data/filter/django/title.html.dj'), input)
-        self.assertEqual(results, 
-          u"\xa1Atom-Powered &lt;b&gt;Robots&lt;/b&gt; Run Amok!\n")
+            os.path.realpath('tests/data/filter/django/title.html.dj'), input_)
+        self.assertEqual(results,
+                         u"\xa1Atom-Powered &lt;b&gt;Robots&lt;/b&gt; Run Amok!\n")
 
     def test_django_entry_title_autoescape_off(self):
         config.load('tests/data/filter/django/test.ini')
         config.parser.set('Planet', 'django_autoescape', 'off')
-        feed = open('tests/data/filter/django/test.xml')
-        input = feed.read(); feed.close()
+        with open('tests/data/filter/django/test.xml') as feed:
+            input_ = feed.read()
         results = dj.run(
-            os.path.realpath('tests/data/filter/django/title.html.dj'), input)
+            os.path.realpath('tests/data/filter/django/title.html.dj'), input_)
         self.assertEqual(results, u"\xa1Atom-Powered <b>Robots</b> Run Amok!\n")
 
     def test_django_config_context(self):
         config.load('tests/data/filter/django/test.ini')
-        feed = open('tests/data/filter/django/test.xml')
-        input = feed.read(); feed.close()
+        with open('tests/data/filter/django/test.xml') as feed:
+            input_ = feed.read()
         results = dj.run(
-            os.path.realpath('tests/data/filter/django/config.html.dj'), input)
+            os.path.realpath('tests/data/filter/django/config.html.dj'), input_)
         self.assertEqual(results, "Django on Venus\n")
-        
+
 
 try:
     from django.conf import settings
 except ImportError:
     logger.warn("Django is not available => can't test django filters")
     for method in dir(DjangoFilterTests):
-        if method.startswith('test_'):  delattr(DjangoFilterTests,method)
+        if method.startswith('test_'):
+            delattr(DjangoFilterTests, method)

--- a/tests/test_filter_genshi.py
+++ b/tests/test_filter_genshi.py
@@ -1,22 +1,27 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, xml.dom.minidom
-from planet import shell, config, logger
+import unittest
+
+from planet import logger, shell
+
 
 class GenshiFilterTests(unittest.TestCase):
-
     def test_addsearch_filter(self):
         testfile = 'tests/data/filter/index.html'
-        filter = 'addsearch.genshi'
-        output = shell.run(filter, open(testfile).read(), mode="filter")
-        self.assertTrue(output.find('<h2>Search</h2>')>=0)
-        self.assertTrue(output.find('<form><input name="q"/></form>')>=0)
-        self.assertTrue(output.find(' href="http://planet.intertwingly.net/opensearchdescription.xml"')>=0)
-        self.assertTrue(output.find('</script>')>=0)
+        the_filter = 'addsearch.genshi'
+        with open(testfile) as fp:
+            output = shell.run(the_filter, fp.read(), mode="filter")
+        self.assertTrue(output.find('<h2>Search</h2>') >= 0)
+        self.assertTrue(output.find('<form><input name="q"/></form>') >= 0)
+        self.assertTrue(output.find(' href="http://planet.intertwingly.net/opensearchdescription.xml"') >= 0)
+        self.assertTrue(output.find('</script>') >= 0)
+
 
 try:
     import genshi
-except:
+except ImportError:
     logger.warn("Genshi is not available => can't test genshi filters")
     for method in dir(GenshiFilterTests):
-        if method.startswith('test_'):  delattr(GenshiFilterTests,method)
+        if method.startswith('test_'):
+            delattr(GenshiFilterTests, method)

--- a/tests/test_filter_tmpl.py
+++ b/tests/test_filter_tmpl.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, sys, glob, new, re, StringIO, time
+import glob
+import new
+import os
+import re
+import unittest
+
 from planet import config
 from planet.shell import tmpl
 
 testfiles = 'tests/data/filter/tmpl/%s.%s'
+
 
 class FilterTmplTest(unittest.TestCase):
     desc_feed_re = re.compile("Description:\s*(.*?)\s*Expect:\s*(.*)\s*-->")
@@ -14,12 +21,11 @@ class FilterTmplTest(unittest.TestCase):
     def eval_feed(self, name):
         # read the test case
         try:
-            testcase = open(testfiles % (name,'xml'))
-            data = testcase.read()
+            with open(testfiles % (name, 'xml')) as testcasefile:
+                data = testcasefile.read()
             description, expect = self.desc_feed_re.search(data).groups()
-            testcase.close()
         except:
-            raise RuntimeError, "can't parse %s" % name
+            raise RuntimeError("can't parse %s" % name)
 
         # map to template info
         results = tmpl.template_info(data)
@@ -34,15 +40,14 @@ class FilterTmplTest(unittest.TestCase):
     def eval_config(self, name):
         # read the test case
         try:
-            testcase = open(testfiles % (name,'ini'))
-            data = testcase.read()
+            with open(testfiles % (name, 'ini')) as testcasefile:
+                data = testcasefile.read()
             description, expect = self.desc_config_re.search(data).groups()
-            testcase.close()
         except:
-            raise RuntimeError, "can't parse %s" % name
+            raise RuntimeError("can't parse %s" % name)
 
         # map to template info
-        config.load(testfiles % (name,'ini'))
+        config.load(testfiles % (name, 'ini'))
         results = tmpl.template_info("<feed/>")
 
         # verify the results
@@ -52,15 +57,16 @@ class FilterTmplTest(unittest.TestCase):
             lhs, rhs = self.simple_re.match(expect).groups()
             self.assertEqual(eval(rhs), eval(lhs, results))
 
+
 # build a test method for each xml test file
-for testcase in glob.glob(testfiles % ('*','xml')):
+for testcase in glob.glob(testfiles % ('*', 'xml')):
     root = os.path.splitext(os.path.basename(testcase))[0]
     func = lambda self, name=root: self.eval_feed(name)
     method = new.instancemethod(func, None, FilterTmplTest)
     setattr(FilterTmplTest, "test_" + root, method)
 
 # build a test method for each ini test file
-for testcase in glob.glob(testfiles % ('*','ini')):
+for testcase in glob.glob(testfiles % ('*', 'ini')):
     root = os.path.splitext(os.path.basename(testcase))[0]
     func = lambda self, name=root: self.eval_config(name)
     method = new.instancemethod(func, None, FilterTmplTest)

--- a/tests/test_filter_xslt.py
+++ b/tests/test_filter_xslt.py
@@ -1,44 +1,46 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, xml.dom.minidom
-from planet import shell, config, logger
+import unittest
+import xml.dom.minidom
+
+from planet import config, logger, shell
+
 
 class XsltFilterTests(unittest.TestCase):
-
     def test_xslt_filter(self):
         config.load('tests/data/filter/translate.ini')
         testfile = 'tests/data/filter/category-one.xml'
 
-        input = open(testfile).read()
-        output = shell.run(config.filters()[0], input, mode="filter")
+        with open(testfile) as fp:
+            input_ = fp.read()
+        output = shell.run(config.filters()[0], input_, mode="filter")
         dom = xml.dom.minidom.parseString(output)
         catterm = dom.getElementsByTagName('category')[0].getAttribute('term')
         self.assertEqual('OnE', catterm)
 
     def test_addsearch_filter(self):
         testfile = 'tests/data/filter/index.html'
-        filter = 'addsearch.xslt'
-        output = shell.run(filter, open(testfile).read(), mode="filter")
-        self.assertTrue(output.find('<h2>Search</h2>')>=0)
-        self.assertTrue(output.find('<form><input name="q"/></form>')>=0)
-        self.assertTrue(output.find(' href="http://planet.intertwingly.net/opensearchdescription.xml"')>=0)
-        self.assertTrue(output.find('</script>')>=0)
+        the_filter = 'addsearch.xslt'
+        with open(testfile) as fp:
+            output = shell.run(the_filter, fp.read(), mode="filter")
+        self.assertTrue(output.find('<h2>Search</h2>') >= 0)
+        self.assertTrue(output.find('<form><input name="q"/></form>') >= 0)
+        self.assertTrue(output.find(' href="http://planet.intertwingly.net/opensearchdescription.xml"') >= 0)
+        self.assertTrue(output.find('</script>') >= 0)
+
 
 try:
     import libxslt
-except:
+except ImportError:
     try:
-        try:
-            # Python 2.5 bug 1704790 workaround (alas, Unix only)
-            import commands
-            if commands.getstatusoutput('xsltproc --version')[0] != 0:
-                raise ImportError
-        except:
-            from subprocess import Popen, PIPE
-            xsltproc=Popen(['xsltproc','--version'],stdout=PIPE,stderr=PIPE)
-            xsltproc.communicate()
-            if xsltproc.returncode != 0: raise ImportError
-    except:
+        from subprocess import Popen, PIPE
+
+        xsltproc = Popen(['xsltproc', '--version'], stdout=PIPE, stderr=PIPE)
+        xsltproc.communicate()
+        if xsltproc.returncode != 0:
+            raise ImportError
+    except ImportError:
         logger.warn("libxslt is not available => can't test xslt filters")
         del XsltFilterTests.test_xslt_filter
         del XsltFilterTests.test_addsearch_filter

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, xml.dom.minidom
-from planet import shell, config, logger
+import unittest
+import xml.dom.minidom
+
+from planet import config, logger, shell
+
 
 class FilterTests(unittest.TestCase):
-
     def test_coral_cdn(self):
         testfile = 'tests/data/filter/coral_cdn.xml'
-        filter = 'coral_cdn_filter.py'
-
-        output = shell.run(filter, open(testfile).read(), mode="filter")
+        the_filter = 'coral_cdn_filter.py'
+        with open(testfile) as fp:
+            output = shell.run(the_filter, fp.read(), mode="filter")
         dom = xml.dom.minidom.parseString(output)
         imgsrcs = [img.getAttribute('src') for img in dom.getElementsByTagName('img')]
         self.assertEqual('http://example.com.nyud.net:8080/foo.png', imgsrcs[0])
@@ -27,9 +30,10 @@ class FilterTests(unittest.TestCase):
 
     def verify_images(self):
         testfile = 'tests/data/filter/excerpt-images.xml'
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         dom = xml.dom.minidom.parseString(output)
         excerpt = dom.getElementsByTagName('planet:excerpt')[0]
@@ -37,50 +41,53 @@ class FilterTests(unittest.TestCase):
         hrefs = [a.getAttribute('href') for a in anchors]
         texts = [a.lastChild.nodeValue for a in anchors]
 
-        self.assertEqual(['inner','outer1','outer2'], hrefs)
-        self.assertEqual(['bar','bar','<img>'], texts)
+        self.assertEqual(['inner', 'outer1', 'outer2'], hrefs)
+        self.assertEqual(['bar', 'bar', '<img>'], texts)
 
     def test_excerpt_lorem_ipsum(self):
         testfile = 'tests/data/filter/excerpt-lorem-ipsum.xml'
         config.load('tests/data/filter/excerpt-lorem-ipsum.ini')
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         dom = xml.dom.minidom.parseString(output)
         excerpt = dom.getElementsByTagName('planet:excerpt')[0]
         self.assertEqual(u'Lorem ipsum dolor sit amet, consectetuer ' +
-            u'adipiscing elit. Nullam velit. Vivamus tincidunt, erat ' +
-            u'in \u2026', excerpt.firstChild.firstChild.nodeValue)
+                         u'adipiscing elit. Nullam velit. Vivamus tincidunt, erat ' +
+                         u'in \u2026', excerpt.firstChild.firstChild.nodeValue)
 
     def test_excerpt_lorem_ipsum_summary(self):
         testfile = 'tests/data/filter/excerpt-lorem-ipsum.xml'
         config.load('tests/data/filter/excerpt-lorem-ipsum.ini')
         config.parser.set('excerpt.py', 'target', 'atom:summary')
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         dom = xml.dom.minidom.parseString(output)
         excerpt = dom.getElementsByTagName('summary')[0]
         self.assertEqual(u'Lorem ipsum dolor sit amet, consectetuer ' +
-            u'adipiscing elit. Nullam velit. Vivamus tincidunt, erat ' +
-            u'in \u2026', excerpt.firstChild.firstChild.nodeValue)
+                         u'adipiscing elit. Nullam velit. Vivamus tincidunt, erat ' +
+                         u'in \u2026', excerpt.firstChild.firstChild.nodeValue)
 
     def test_stripAd_yahoo(self):
         testfile = 'tests/data/filter/stripAd-yahoo.xml'
         config.load('tests/data/filter/stripAd-yahoo.ini')
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         dom = xml.dom.minidom.parseString(output)
         excerpt = dom.getElementsByTagName('content')[0]
         self.assertEqual(u'before--after',
-            excerpt.firstChild.firstChild.nodeValue)
+                         excerpt.firstChild.firstChild.nodeValue)
 
     def test_xpath_filter1(self):
         config.load('tests/data/filter/xpath-sifter.ini')
@@ -93,17 +100,19 @@ class FilterTests(unittest.TestCase):
     def verify_xpath(self):
         testfile = 'tests/data/filter/category-one.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertEqual('', output)
 
         testfile = 'tests/data/filter/category-two.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertNotEqual('', output)
 
@@ -112,17 +121,19 @@ class FilterTests(unittest.TestCase):
 
         testfile = 'tests/data/filter/category-one.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertEqual('', output)
 
         testfile = 'tests/data/filter/category-two.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertNotEqual('', output)
 
@@ -131,54 +142,52 @@ class FilterTests(unittest.TestCase):
 
         testfile = 'tests/data/filter/category-one.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertNotEqual('', output)
 
         testfile = 'tests/data/filter/category-two.xml'
 
-        output = open(testfile).read()
-        for filter in config.filters():
-            output = shell.run(filter, output, mode="filter")
+        with open(testfile) as fp:
+            output = fp.read()
+        for each_filter in config.filters():
+            output = shell.run(each_filter, output, mode="filter")
 
         self.assertEqual('', output)
 
     def test_xhtml2html_filter(self):
         testfile = 'tests/data/filter/index.html'
-        filter = 'xhtml2html.plugin?quote_attr_values=True'
-        output = shell.run(filter, open(testfile).read(), mode="filter")
-        self.assertTrue(output.find('/>')<0)
-        self.assertTrue(output.find('</script>')>=0)
+        the_filter = 'xhtml2html.plugin?quote_attr_values=True'
+        with open(testfile) as fp:
+            output = shell.run(the_filter, fp.read(), mode="filter")
+        self.assertTrue(output.find('/>') < 0)
+        self.assertTrue(output.find('</script>') >= 0)
+
 
 try:
     from subprocess import Popen, PIPE
 
     _no_sed = True
-    if _no_sed:
-        try:
-            # Python 2.5 bug 1704790 workaround (alas, Unix only)
-            import commands
-            if commands.getstatusoutput('sed --version')[0]==0: _no_sed = False 
-        except:
-            pass
 
     if _no_sed:
         try:
-            sed = Popen(['sed','--version'],stdout=PIPE,stderr=PIPE)
+            sed = Popen(['sed', '--version'], stdout=PIPE, stderr=PIPE)
             sed.communicate()
-            if sed.returncode == 0: _no_sed = False
+            if sed.returncode == 0:
+                _no_sed = False
         except WindowsError:
             pass
 
     if _no_sed:
         logger.warn("sed is not available => can't test stripAd_yahoo")
-        del FilterTests.test_stripAd_yahoo      
+        del FilterTests.test_stripAd_yahoo
 
     try:
         import libxml2
-    except:
+    except ImportError:
         logger.warn("libxml2 is not available => can't test xpath_sifter")
         del FilterTests.test_xpath_filter1
         del FilterTests.test_xpath_filter2
@@ -186,4 +195,5 @@ try:
 except ImportError:
     logger.warn("Popen is not available => can't test standard filters")
     for method in dir(FilterTests):
-        if method.startswith('test_'):  delattr(FilterTests,method)
+        if method.startswith('test_'):
+            delattr(FilterTests, method)

--- a/tests/test_foaf.py
+++ b/tests/test_foaf.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, shutil
-from planet.foaf import foaf2config
+import os
+import shutil
+import unittest
 from ConfigParser import ConfigParser
+
 from planet import config, logger
+from planet.foaf import foaf2config
 
 workdir = 'tests/work/config/cache'
 
@@ -39,6 +43,7 @@ test_foaf_document = '''
 </rdf:RDF> 
 '''.strip()
 
+
 class FoafTest(unittest.TestCase):
     """
     Test the foaf2config function
@@ -62,13 +67,13 @@ class FoafTest(unittest.TestCase):
         self.assertEqual('Danny Ayers', self.config.get(testfeed, 'name'))
 
     def test_no_foaf_name(self):
-        test = test_foaf_document.replace('foaf:name','foaf:title')
+        test = test_foaf_document.replace('foaf:name', 'foaf:title')
         foaf2config(test, self.config)
         self.assertEqual('Raw Blog by Danny Ayers',
-           self.config.get(testfeed, 'name'))
+                         self.config.get(testfeed, 'name'))
 
     def test_no_weblog(self):
-        test = test_foaf_document.replace('rdfs:seeAlso','rdfs:seealso')
+        test = test_foaf_document.replace('rdfs:seeAlso', 'rdfs:seealso')
         foaf2config(test, self.config)
         self.assertFalse(self.config.has_section(testfeed))
 
@@ -87,41 +92,43 @@ class FoafTest(unittest.TestCase):
         feeds = config.subscriptions()
         feeds.sort()
         self.assertEqual(['http://api.flickr.com/services/feeds/' +
-            'photos_public.gne?id=77366516@N00',
-            'http://del.icio.us/rss/eliast',
-            'http://torrez.us/feed/rdf'], feeds)
+                          'photos_public.gne?id=77366516@N00',
+                          'http://del.icio.us/rss/eliast',
+                          'http://torrez.us/feed/rdf'], feeds)
 
     def test_multiple_subscriptions(self):
         config.load('tests/data/config/foaf-multiple.ini')
-        self.assertEqual(2,len(config.reading_lists()))
+        self.assertEqual(2, len(config.reading_lists()))
         feeds = config.subscriptions()
         feeds.sort()
-        self.assertEqual(5,len(feeds))
+        self.assertEqual(5, len(feeds))
         self.assertEqual(['http://api.flickr.com/services/feeds/' +
-            'photos_public.gne?id=77366516@N00',
-            'http://api.flickr.com/services/feeds/' +
-            'photos_public.gne?id=SOMEID',
-            'http://del.icio.us/rss/SOMEID',
-            'http://del.icio.us/rss/eliast',
-            'http://torrez.us/feed/rdf'], feeds)
+                          'photos_public.gne?id=77366516@N00',
+                          'http://api.flickr.com/services/feeds/' +
+                          'photos_public.gne?id=SOMEID',
+                          'http://del.icio.us/rss/SOMEID',
+                          'http://del.icio.us/rss/eliast',
+                          'http://torrez.us/feed/rdf'], feeds)
 
     def test_recursive(self):
         config.load('tests/data/config/foaf-deep.ini')
         feeds = config.subscriptions()
         feeds.sort()
         self.assertEqual(['http://api.flickr.com/services/feeds/photos_public.gne?id=77366516@N00',
-        'http://del.icio.us/rss/eliast', 'http://del.icio.us/rss/leef',
-        'http://del.icio.us/rss/rubys', 'http://intertwingly.net/blog/atom.xml',
-        'http://thefigtrees.net/lee/life/atom.xml',
-        'http://torrez.us/feed/rdf'], feeds)
+                          'http://del.icio.us/rss/eliast', 'http://del.icio.us/rss/leef',
+                          'http://del.icio.us/rss/rubys', 'http://intertwingly.net/blog/atom.xml',
+                          'http://thefigtrees.net/lee/life/atom.xml',
+                          'http://torrez.us/feed/rdf'], feeds)
+
 
 # these tests only make sense if libRDF is installed
 try:
     import RDF
-except:
+except ImportError:
     logger.warn("Redland RDF is not available => can't test FOAF reading lists")
     for key in FoafTest.__dict__.keys():
-        if key.startswith('test_'): delattr(FoafTest, key)
+        if key.startswith('test_'):
+            delattr(FoafTest, key)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_idindex.py
+++ b/tests/test_idindex.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, planet
-from planet import idindex, config
+import planet
+import unittest
+import os
+import shutil
+
+from planet import config, idindex
+
 
 class idIndexTest(unittest.TestCase):
-
     def setUp(self):
         # silence errors
         self.original_logger = planet.logger
-        planet.getLogger('CRITICAL',None)
+        planet.getLogger('CRITICAL', None)
 
     def tearDown(self):
         idindex.destroy()
@@ -22,7 +27,7 @@ class idIndexTest(unittest.TestCase):
         index[filename('', iri.decode('utf-8'))] = 'data'
         index[filename('', u'1234')] = 'data'
         index.close()
-        
+
     def test_index_spider(self):
         import test_spider
         config.load(test_spider.configfile)
@@ -41,7 +46,6 @@ class idIndexTest(unittest.TestCase):
             self.assertEqual('http://intertwingly.net/code/venus/tests/data/spider/testfeed3.rss', index['planet.intertwingly.net,2006,testfeed3,1'])
             index.close()
         finally:
-            import os, shutil
             shutil.rmtree(test_spider.workdir)
             os.removedirs(os.path.split(test_spider.workdir)[0])
 
@@ -56,19 +60,21 @@ class idIndexTest(unittest.TestCase):
 
         for key in index.keys():
             value = index[key]
-            if value.find('testfeed2')>0: index[key] = value.swapcase()
+            if value.find('testfeed2') > 0:
+                index[key] = value.swapcase()
         index.close()
 
         from planet.splice import splice
         doc = splice()
 
-        self.assertEqual(8,len(doc.getElementsByTagName('entry')))
-        self.assertEqual(4,len(doc.getElementsByTagName('planet:source')))
-        self.assertEqual(12,len(doc.getElementsByTagName('planet:name')))
+        self.assertEqual(8, len(doc.getElementsByTagName('entry')))
+        self.assertEqual(4, len(doc.getElementsByTagName('planet:source')))
+        self.assertEqual(12, len(doc.getElementsByTagName('planet:name')))
 
 try:
-    module = 'dbhash'
+    import dbhash
 except ImportError:
     planet.logger.warn("dbhash is not available => can't test id index")
     for method in dir(idIndexTest):
-        if method.startswith('test_'):  delattr(idIndexTest,method)
+        if method.startswith('test_'):
+            delattr(idIndexTest, method)

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import unittest
-from planet.opml import opml2config
 from ConfigParser import ConfigParser
+
+from planet.opml import opml2config
+
 
 class OpmlTest(unittest.TestCase):
     """
@@ -21,7 +24,7 @@ class OpmlTest(unittest.TestCase):
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_wrong_element(self):
         opml2config('''<feed    type="rss"
@@ -35,7 +38,7 @@ class OpmlTest(unittest.TestCase):
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_illformed_xml_after(self):
         opml2config('''<outline type="rss"
@@ -43,7 +46,7 @@ class OpmlTest(unittest.TestCase):
                                 text="sample feed"/>
                        <bad stuff after>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     #
     # Type
@@ -54,21 +57,21 @@ class OpmlTest(unittest.TestCase):
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_type_uppercase(self):
         opml2config('''<outline type="RSS"
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_type_atom(self):
         opml2config('''<outline type="atom"
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_wrong_type(self):
         opml2config('''<outline type="other"
@@ -82,7 +85,7 @@ class OpmlTest(unittest.TestCase):
                                 xmlUrl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     #
     # xmlUrl
@@ -93,7 +96,7 @@ class OpmlTest(unittest.TestCase):
                                 xmlurl="http://example.com/feed.xml"
                                 text="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_missing_xmlUrl(self):
         opml2config('''<outline type="rss"
@@ -115,7 +118,7 @@ class OpmlTest(unittest.TestCase):
                                 xmlUrl="http://example.com/feed.xml"
                                 title="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_missing_text(self):
         opml2config('''<outline type="rss"
@@ -135,7 +138,7 @@ class OpmlTest(unittest.TestCase):
                                 text=""
                                 title="sample feed"/>''', self.config)
         self.assertEqual('sample feed',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_blank_text_blank_title(self):
         opml2config('''<outline type="rss"
@@ -150,28 +153,29 @@ class OpmlTest(unittest.TestCase):
                                 text="Se\xc3\xb1or Frog\xe2\x80\x99s"/>''',
                     self.config)
         self.assertEqual('Se\xc3\xb1or Frog\xe2\x80\x99s',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_text_win_1252(self):
         opml2config('''<outline type="rss"
                                 xmlUrl="http://example.com/feed.xml"
                                 text="Se\xf1or Frog\x92s"/>''', self.config)
         self.assertEqual('Se\xc3\xb1or Frog\xe2\x80\x99s',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_text_entity(self):
         opml2config('''<outline type="rss"
                                 xmlUrl="http://example.com/feed.xml"
                                 text="Se&ntilde;or Frog&rsquo;s"/>''', self.config)
         self.assertEqual('Se\xc3\xb1or Frog\xe2\x80\x99s',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
 
     def test_text_double_escaped(self):
         opml2config('''<outline type="rss"
                                 xmlUrl="http://example.com/feed.xml"
                                 text="Se&amp;ntilde;or Frog&amp;rsquo;s"/>''', self.config)
         self.assertEqual('Se\xc3\xb1or Frog\xe2\x80\x99s',
-           self.config.get("http://example.com/feed.xml", 'name'))
+                         self.config.get("http://example.com/feed.xml", 'name'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reconstitute.py
+++ b/tests/test_reconstitute.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, sys, glob, new, re, StringIO, time
+import StringIO
+import glob
+import new
+import os
+import re
+import unittest
+
 from planet import feedparser
 from planet.reconstitute import reconstitute
 from planet.scrub import scrub
 
 testfiles = 'tests/data/reconstitute/%s.xml'
+
 
 class ReconstituteTest(unittest.TestCase):
     desc_re = re.compile("Description:\s*(.*?)\s*Expect:\s*(.*)\s*-->")
@@ -14,17 +22,16 @@ class ReconstituteTest(unittest.TestCase):
     def eval(self, name):
         # read the test case
         try:
-            testcase = open(testfiles % name)
-            data = testcase.read()
-            description, expect = self.desc_re.search(data).groups()
-            testcase.close()
+            with open(testfiles % name) as testcasefile:
+                data = testcasefile.read()
+                description, expect = self.desc_re.search(data).groups()
         except:
-            raise RuntimeError, "can't parse %s" % name
+            raise RuntimeError("can't parse %s" % name)
 
         # parse and reconstitute to a string
         work = StringIO.StringIO()
         results = feedparser.parse(data)
-        scrub(testfiles%name, results)
+        scrub(testfiles % name, results)
         reconstitute(results, results.entries[0]).writexml(work)
 
         # verify the results
@@ -36,6 +43,7 @@ class ReconstituteTest(unittest.TestCase):
         else:
             lhs, rhs = self.simple_re.match(expect).groups()
             self.assertEqual(eval(rhs), eval(lhs, results.entries[0]))
+
 
 # build a test method for each test file
 for testcase in glob.glob(testfiles % '*'):

--- a/tests/test_rlists.py
+++ b/tests/test_rlists.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, shutil
-from planet import config, opml
-from os.path import split
-from glob import glob
+import os
+import shutil
+import unittest
 from ConfigParser import ConfigParser
+from glob import glob
+from os.path import split
+
+from planet import config
 
 workdir = os.path.join('tests', 'work', 'config', 'cache')
+
 
 class ReadingListTest(unittest.TestCase):
     def setUp(self):
@@ -22,12 +27,12 @@ class ReadingListTest(unittest.TestCase):
         feeds = [split(feed)[1] for feed in config.subscriptions()]
         feeds.sort()
         self.assertEqual(['testfeed0.atom', 'testfeed1a.atom',
-            'testfeed2.atom', 'testfeed3.rss'], feeds)
+                          'testfeed2.atom', 'testfeed3.rss'], feeds)
 
     # dictionaries
 
     def test_feed_options(self):
-        feeds = dict([(split(feed)[1],feed) for feed in config.subscriptions()])
+        feeds = dict([(split(feed)[1], feed) for feed in config.subscriptions()])
         feed1 = feeds['testfeed1a.atom']
         self.assertEqual('one', config.feed_options(feed1)['name'])
 
@@ -37,8 +42,8 @@ class ReadingListTest(unittest.TestCase):
     # dictionaries
 
     def test_cache(self):
-        cache = glob(os.path.join(workdir,'lists','*'))
-        self.assertEqual(1,len(cache))
+        cache = glob(os.path.join(workdir, 'lists', '*'))
+        self.assertEqual(1, len(cache))
 
         parser = ConfigParser()
         parser.read(cache[0])
@@ -46,4 +51,4 @@ class ReadingListTest(unittest.TestCase):
         feeds = [split(feed)[1] for feed in parser.sections()]
         feeds.sort()
         self.assertEqual(['opml.xml', 'testfeed0.atom', 'testfeed1a.atom',
-            'testfeed2.atom', 'testfeed3.rss'], feeds)
+                          'testfeed2.atom', 'testfeed3.rss'], feeds)

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, StringIO, time
+import StringIO
+import time
+import unittest
 from copy import deepcopy
+
+from planet import config, feedparser
 from planet.scrub import scrub
-from planet import feedparser, config
 
 feed = '''
 <feed xmlns='http://www.w3.org/2005/Atom' xml:base="http://example.com/">
@@ -35,30 +39,30 @@ summary_type = html
 content_type = html
 '''
 
-class ScrubTest(unittest.TestCase):
 
+class ScrubTest(unittest.TestCase):
     def test_scrub_ignore(self):
         base = feedparser.parse(feed)
 
-        self.assertTrue(base.entries[0].has_key('author'))
-        self.assertTrue(base.entries[0].has_key('author_detail'))
-        self.assertTrue(base.entries[0].has_key('id'))
-        self.assertTrue(base.entries[0].has_key('updated'))
-        self.assertTrue(base.entries[0].has_key('updated_parsed'))
-        self.assertTrue(base.entries[0].summary_detail.has_key('language'))
+        self.assertTrue('author' in base.entries[0].keys())
+        self.assertTrue('author_detail' in base.entries[0].keys())
+        self.assertTrue('id' in base.entries[0].keys())
+        self.assertTrue('updated' in base.entries[0].keys())
+        self.assertTrue('updated_parsed' in base.entries[0].keys())
+        self.assertTrue('language' in base.entries[0].summary_detail.keys())
 
         config.parser.readfp(StringIO.StringIO(configData))
         config.parser.set('testfeed', 'ignore_in_feed',
-          'author id updated xml:lang')
+                          'author id updated xml:lang')
         data = deepcopy(base)
         scrub('testfeed', data)
 
-        self.assertFalse(data.entries[0].has_key('author'))
-        self.assertFalse(data.entries[0].has_key('author_detail'))
-        self.assertFalse(data.entries[0].has_key('id'))
-        self.assertFalse(data.entries[0].has_key('updated'))
-        self.assertFalse(data.entries[0].has_key('updated_parsed'))
-        self.assertFalse(data.entries[0].summary_detail.has_key('language'))
+        self.assertFalse('author' in data.entries[0].keys())
+        self.assertFalse('author_detail' in data.entries[0].keys())
+        self.assertFalse('id' in data.entries[0].keys())
+        self.assertFalse('updated' in data.entries[0].keys())
+        self.assertFalse('updated_parsed' in data.entries[0].keys())
+        self.assertFalse('language' in data.entries[0].summary_detail.keys())
 
     def test_scrub_type(self):
         base = feedparser.parse(feed)
@@ -80,13 +84,13 @@ class ScrubTest(unittest.TestCase):
     def test_scrub_future(self):
         base = feedparser.parse(feed)
         self.assertEqual(1, len(base.entries))
-        self.assertTrue(base.entries[0].has_key('updated'))
+        self.assertTrue('updated' in base.entries[0].keys())
 
         config.parser.readfp(StringIO.StringIO(configData))
         config.parser.set('testfeed', 'future_dates', 'ignore_date')
         data = deepcopy(base)
         scrub('testfeed', data)
-        self.assertFalse(data.entries[0].has_key('updated'))
+        self.assertFalse('updated' in data.entries[0].keys())
 
         config.parser.set('testfeed', 'future_dates', 'ignore_entry')
         data = deepcopy(base)
@@ -96,29 +100,29 @@ class ScrubTest(unittest.TestCase):
     def test_scrub_xmlbase(self):
         base = feedparser.parse(feed)
         self.assertEqual('http://example.com/',
-             base.entries[0].title_detail.base)
+                         base.entries[0].title_detail.base)
 
         config.parser.readfp(StringIO.StringIO(configData))
         config.parser.set('testfeed', 'xml_base', 'feed_alternate')
         data = deepcopy(base)
         scrub('testfeed', data)
         self.assertEqual('http://example.com/feed/',
-             data.entries[0].title_detail.base)
+                         data.entries[0].title_detail.base)
 
         config.parser.set('testfeed', 'xml_base', 'entry_alternate')
         data = deepcopy(base)
         scrub('testfeed', data)
         self.assertEqual('http://example.com/entry/1/',
-             data.entries[0].title_detail.base)
+                         data.entries[0].title_detail.base)
 
         config.parser.set('testfeed', 'xml_base', 'base/')
         data = deepcopy(base)
         scrub('testfeed', data)
         self.assertEqual('http://example.com/base/',
-             data.entries[0].title_detail.base)
+                         data.entries[0].title_detail.base)
 
         config.parser.set('testfeed', 'xml_base', 'http://example.org/data/')
         data = deepcopy(base)
         scrub('testfeed', data)
         self.assertEqual('http://example.org/data/',
-             data.entries[0].title_detail.base)
+                         data.entries[0].title_detail.base)

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-import unittest, os, glob, calendar, shutil, time
-from planet.spider import filename, spiderPlanet, writeCache
-from planet import feedparser, config
+import calendar
+import glob
+import os
+import shutil
+import time
+import unittest
+
 import planet
+from planet import config, feedparser
+from planet.spider import filename, spiderPlanet, writeCache
 
 workdir = 'tests/work/spider/cache'
 testfeed = 'tests/data/spider/testfeed%s.atom'
 configfile = 'tests/data/spider/config.ini'
 
+
 class SpiderTest(unittest.TestCase):
     def setUp(self):
         # silence errors
         self.original_logger = planet.logger
-        planet.getLogger('CRITICAL',None)
+        planet.getLogger('CRITICAL', None)
 
         try:
-             os.makedirs(workdir)
+            os.makedirs(workdir)
         except:
-             self.tearDown()
-             os.makedirs(workdir)
-    
+            self.tearDown()
+            os.makedirs(workdir)
+
     def tearDown(self):
         shutil.rmtree(workdir)
         os.removedirs(os.path.split(workdir)[0])
@@ -28,21 +36,21 @@ class SpiderTest(unittest.TestCase):
 
     def test_filename(self):
         self.assertEqual(os.path.join('.', 'example.com,index.html'),
-            filename('.', 'http://example.com/index.html'))
+                         filename('.', 'http://example.com/index.html'))
         self.assertEqual(os.path.join('.',
-            'planet.intertwingly.net,2006,testfeed1,1'),
-            filename('.', u'tag:planet.intertwingly.net,2006:testfeed1,1'))
+                                      'planet.intertwingly.net,2006,testfeed1,1'),
+                         filename('.', u'tag:planet.intertwingly.net,2006:testfeed1,1'))
         self.assertEqual(os.path.join('.',
-            '00000000-0000-0000-0000-000000000000'),
-            filename('.', u'urn:uuid:00000000-0000-0000-0000-000000000000'))
+                                      '00000000-0000-0000-0000-000000000000'),
+                         filename('.', u'urn:uuid:00000000-0000-0000-0000-000000000000'))
 
         # Requires Python 2.3
         try:
             import encodings.idna
-        except:
+        except ImportError:
             return
         self.assertEqual(os.path.join('.', 'xn--8ws00zhy3a.com'),
-            filename('.', u'http://www.\u8a79\u59c6\u65af.com/'))
+                         filename('.', u'http://www.\u8a79\u59c6\u65af.com/'))
 
     def spiderFeed(self, feed_uri):
         feed_info = feedparser.parse('<feed/>')
@@ -50,7 +58,7 @@ class SpiderTest(unittest.TestCase):
         writeCache(feed_uri, feed_info, data)
 
     def verify_spiderFeed(self):
-        files = glob.glob(workdir+"/*")
+        files = glob.glob(workdir + "/*")
         files.sort()
 
         # verify that exactly four files + one sources dir were produced
@@ -58,16 +66,16 @@ class SpiderTest(unittest.TestCase):
 
         # verify that the file names are as expected
         self.assertTrue(os.path.join(workdir,
-            'planet.intertwingly.net,2006,testfeed1,1') in files)
+                                     'planet.intertwingly.net,2006,testfeed1,1') in files)
 
         # verify that the file timestamps match atom:updated
         data = feedparser.parse(files[2])
         self.assertEqual(['application/atom+xml'], [link.type
-            for link in data.entries[0].source.links if link.rel=='self'])
+                                                    for link in data.entries[0].source.links if link.rel == 'self'])
         self.assertEqual('one', data.entries[0].source.planet_name)
         self.assertEqual('2006-01-03T00:00:00Z', data.entries[0].updated)
         self.assertEqual(os.stat(files[2]).st_mtime,
-            calendar.timegm(data.entries[0].updated_parsed))
+                         calendar.timegm(data.entries[0].updated_parsed))
 
     def test_spiderFeed(self):
         config.load(configfile)
@@ -77,31 +85,31 @@ class SpiderTest(unittest.TestCase):
     def test_spiderFeed_retroactive_filter(self):
         config.load(configfile)
         self.spiderFeed(testfeed % '1b')
-        self.assertEqual(5, len(glob.glob(workdir+"/*")))
+        self.assertEqual(5, len(glob.glob(workdir + "/*")))
         config.parser.set('Planet', 'filter', 'two')
         self.spiderFeed(testfeed % '1b')
-        self.assertEqual(1, len(glob.glob(workdir+"/*")))
+        self.assertEqual(1, len(glob.glob(workdir + "/*")))
 
     def test_spiderFeed_blacklist(self):
         config.load(configfile)
         self.spiderFeed(testfeed % '1b')
 
         # verify that exactly four entries were produced
-        self.assertEqual(4, len(glob.glob(workdir+"/planet*")))
+        self.assertEqual(4, len(glob.glob(workdir + "/planet*")))
 
         # verify that the file names are as expected
         self.assertTrue(os.path.exists(os.path.join(workdir,
-            'planet.intertwingly.net,2006,testfeed1,1')))
-        
+                                                    'planet.intertwingly.net,2006,testfeed1,1')))
+
         os.mkdir(os.path.join(workdir, "blacklist"))
 
         os.rename(os.path.join(workdir,
-            'planet.intertwingly.net,2006,testfeed1,1'),
-                  os.path.join(workdir, "blacklist", 
-            'planet.intertwingly.net,2006,testfeed1,1'))
+                               'planet.intertwingly.net,2006,testfeed1,1'),
+                  os.path.join(workdir, "blacklist",
+                               'planet.intertwingly.net,2006,testfeed1,1'))
 
-	self.spiderFeed(testfeed % '1b')
-        self.assertEqual(3, len(glob.glob(workdir+"/planet*")))
+        self.spiderFeed(testfeed % '1b')
+        self.assertEqual(3, len(glob.glob(workdir + "/planet*")))
 
     def test_spiderUpdate(self):
         config.load(configfile)
@@ -112,27 +120,27 @@ class SpiderTest(unittest.TestCase):
     def test_spiderFeedUpdatedEntries(self):
         config.load(configfile)
         self.spiderFeed(testfeed % '4')
-        self.assertEqual(2, len(glob.glob(workdir+"/*")))
-        data = feedparser.parse(workdir + 
-            '/planet.intertwingly.net,2006,testfeed4')
+        self.assertEqual(2, len(glob.glob(workdir + "/*")))
+        data = feedparser.parse(workdir +
+                                '/planet.intertwingly.net,2006,testfeed4')
         self.assertEqual(u'three', data.entries[0].content[0].value)
 
     def verify_spiderPlanet(self):
-        files = glob.glob(workdir+"/*")
+        files = glob.glob(workdir + "/*")
 
         # verify that exactly eight files + 1 source dir were produced
         self.assertEqual(14, len(files))
 
         # verify that the file names are as expected
         self.assertTrue(os.path.join(workdir,
-            'planet.intertwingly.net,2006,testfeed1,1') in files)
+                                     'planet.intertwingly.net,2006,testfeed1,1') in files)
         self.assertTrue(os.path.join(workdir,
-            'planet.intertwingly.net,2006,testfeed2,1') in files)
+                                     'planet.intertwingly.net,2006,testfeed2,1') in files)
 
-        data = feedparser.parse(workdir + 
-            '/planet.intertwingly.net,2006,testfeed3,1')
+        data = feedparser.parse(workdir +
+                                '/planet.intertwingly.net,2006,testfeed3,1')
         self.assertEqual(['application/rss+xml'], [link.type
-            for link in data.entries[0].source.links if link.rel=='self'])
+                                                   for link in data.entries[0].source.links if link.rel == 'self'])
         self.assertEqual('three', data.entries[0].source.author_detail.name)
         self.assertEqual('three', data.entries[0].source['planet_css-id'])
 
@@ -142,27 +150,30 @@ class SpiderTest(unittest.TestCase):
         self.verify_spiderPlanet()
 
     def test_spiderThreads(self):
-        config.load(configfile.replace('config','threaded'))
-        _PORT = config.parser.getint('Planet','test_port')
+        config.load(configfile.replace('config', 'threaded'))
+        _PORT = config.parser.getint('Planet', 'test_port')
 
         log = []
         from SimpleHTTPServer import SimpleHTTPRequestHandler
+
         class TestRequestHandler(SimpleHTTPRequestHandler):
-            def log_message(self, format, *args):
+            def log_message(self, format_, *args):
                 log.append(args)
 
         from threading import Thread
+
         class TestServerThread(Thread):
-          def __init__(self):
-              self.ready = 0
-              self.done = 0
-              Thread.__init__(self)
-          def run(self):
-              from BaseHTTPServer import HTTPServer
-              httpd = HTTPServer(('',_PORT), TestRequestHandler)
-              self.ready = 1
-              while not self.done:
-                  httpd.handle_request()
+            def __init__(self):
+                self.ready = 0
+                self.done = 0
+                Thread.__init__(self)
+
+            def run(self):
+                from BaseHTTPServer import HTTPServer
+                httpd_ = HTTPServer(('', _PORT), TestRequestHandler)
+                self.ready = 1
+                while not self.done:
+                    httpd_.handle_request()
 
         httpd = TestServerThread()
         httpd.start()
@@ -178,6 +189,6 @@ class SpiderTest(unittest.TestCase):
 
         status = [int(rec[1]) for rec in log if str(rec[0]).startswith('GET ')]
         status.sort()
-        self.assertEqual([200,200,200,200,404], status)
+        self.assertEqual([200, 200, 200, 200, 404], status)
 
         self.verify_spiderPlanet()

--- a/tests/test_splice.py
+++ b/tests/test_splice.py
@@ -1,34 +1,36 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import unittest
-from planet.splice import splice, config
+
+from planet.splice import config, splice
 
 configfile = 'tests/data/splice/config.ini'
 
-class SpliceTest(unittest.TestCase):
 
+class SpliceTest(unittest.TestCase):
     def test_splice(self):
         config.load(configfile)
         doc = splice()
-        self.assertEqual(12,len(doc.getElementsByTagName('entry')))
-        self.assertEqual(4,len(doc.getElementsByTagName('planet:source')))
-        self.assertEqual(16,len(doc.getElementsByTagName('planet:name')))
+        self.assertEqual(12, len(doc.getElementsByTagName('entry')))
+        self.assertEqual(4, len(doc.getElementsByTagName('planet:source')))
+        self.assertEqual(16, len(doc.getElementsByTagName('planet:name')))
 
         self.assertEqual('test planet',
-            doc.getElementsByTagName('title')[0].firstChild.nodeValue)
+                         doc.getElementsByTagName('title')[0].firstChild.nodeValue)
 
     def test_splice_unsub(self):
         config.load(configfile)
         config.parser.remove_section('tests/data/spider/testfeed2.atom')
         doc = splice()
-        self.assertEqual(8,len(doc.getElementsByTagName('entry')))
-        self.assertEqual(3,len(doc.getElementsByTagName('planet:source')))
-        self.assertEqual(11,len(doc.getElementsByTagName('planet:name')))
+        self.assertEqual(8, len(doc.getElementsByTagName('entry')))
+        self.assertEqual(3, len(doc.getElementsByTagName('planet:source')))
+        self.assertEqual(11, len(doc.getElementsByTagName('planet:name')))
 
     def test_splice_new_feed_items(self):
         config.load(configfile)
-        config.parser.set('Planet','new_feed_items','3')
+        config.parser.set('Planet', 'new_feed_items', '3')
         doc = splice()
-        self.assertEqual(9,len(doc.getElementsByTagName('entry')))
-        self.assertEqual(4,len(doc.getElementsByTagName('planet:source')))
-        self.assertEqual(13,len(doc.getElementsByTagName('planet:name')))
+        self.assertEqual(9, len(doc.getElementsByTagName('entry')))
+        self.assertEqual(4, len(doc.getElementsByTagName('planet:source')))
+        self.assertEqual(13, len(doc.getElementsByTagName('planet:name')))

--- a/tests/test_subconfig.py
+++ b/tests/test_subconfig.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+# coding=utf-8
 
-from test_config_csv import ConfigCsvTest
 from planet import config
+from test_config_csv import ConfigCsvTest
+
 
 class SubConfigTest(ConfigCsvTest):
     def setUp(self):

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import unittest
-from planet import config
 from os.path import split
+
+from planet import config
+
 
 class ThemesTest(unittest.TestCase):
     def setUp(self):
@@ -12,13 +15,13 @@ class ThemesTest(unittest.TestCase):
 
     def test_template_directories(self):
         self.assertEqual(['foo', 'bar', 'asf', 'config', 'common'],
-            [split(dir)[1] for dir in config.template_directories()])
+                         [split(each_dir)[1] for each_dir in config.template_directories()])
 
     # administrivia
 
     def test_template(self):
-        self.assertEqual(1, len([1 for file in config.template_files()
-            if file == 'index.html.xslt']))
+        self.assertEqual(1, len([1 for each_file in config.template_files()
+                                 if each_file == 'index.html.xslt']))
 
     def test_feeds(self):
         feeds = config.subscriptions()
@@ -55,5 +58,5 @@ class ThemesTest(unittest.TestCase):
 
     def test_template_options(self):
         option = config.template_options('index.html.xslt')
-        self.assertEqual('7',  option['days_per_page'])
+        self.assertEqual('7', option['days_per_page'])
         self.assertEqual('50', option['items_per_page'])


### PR DESCRIPTION
At the risk of pushing too large of a pull request here is a quick cleanup of the tests in this module.  I have focused on PEP8 but also ripped out code for Python 2.2 and updated code for 2.7.  The eventual goal (for me) is getting this running on Python 2.7 and Python 3.4+.  This is not Python3 compatible at the moment and won't be until I dive deeper into the core.

Some key things:

- Renamed things that were shadowing builtins.
- Made Exception catching more specific
- Lots of whitespace fixes
- Added file encoding headers
- Add file context managers instead of manual .open() .close()
- Modern print statements (including `from __future__ import print_function`
- .has_key() has been depreciated. now using the `in` keyword
- Modern Exception statements (i.e. `raise RuntimeError, "can't parse %s" % name` -> `raise RuntimeError("can't parse %s" % name)`

All the tests pass on my machine with the exception of Django and RDF which have both changed significantly since this package was last updated.

Notes:
I had to do some shenanigans to get dbhash to run on my macOS machine but those tests pass.  
macOS's `sed` doesn't have a `--version` flag.  Or even a version number which is super bizarre.  Those tests pass when they are forced to run.