### PR TITLE
Fix rendering of Genshi HTML output and encode the output as UTF-8.

### DIFF
--- a/planet/shell/_genshi.py
+++ b/planet/shell/_genshi.py
@@ -137,7 +137,11 @@ def run(script, doc, output_file=None, options={}):
         context.push(vars)
 
     # apply template
-    output=tmpl.generate(context).render('xml')
+    if output_file.endswith('.xml'):
+        method = 'xml'
+    else:
+        method = 'xhtml'
+    output = tmpl.generate(context).render(method)
 
     if output_file:
         out_file = open(output_file,'w')

--- a/planet/shell/_genshi.py
+++ b/planet/shell/_genshi.py
@@ -141,7 +141,7 @@ def run(script, doc, output_file=None, options={}):
 
     if output_file:
         out_file = open(output_file,'w')
-        out_file.write(output)
+        out_file.write(output.encode('utf-8'))
         out_file.close()
     else:
         return output


### PR DESCRIPTION
Using the `xml` rendering method leaves an XML declaration at the top, which doesn't play nice with some browsers, so it's better to use the `xhtml` method in such cases.

Also, ensure encode the output as UTF-8. Currently, if `output` contains any non-ASCII characters, Python will refuse to write out the string.